### PR TITLE
CodeCov CI

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -2,8 +2,7 @@ name: codecov
 
 on:
   workflow_run:
-    push:
-    # branches: [ "main" ]
+    branches: [ "feature/codecov" ]
     workflows: ["run-pytest"]
     types:
         - completed

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -2,6 +2,7 @@ name: codecov
 
 on:
   workflow_run:
+    push:
     # branches: [ "main" ]
     workflows: ["run-pytest"]
     types:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -2,6 +2,7 @@ name: codecov
 
 on:
   workflow_run:
+    pull_request:
     branches: [ "feature/codecov" ]
     workflows: ["run-pytest"]
     types:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,26 @@
+name: codecov
+
+on:
+  workflow_run:
+    # branches: [ "main" ]
+    workflows: ["run-pytest"]
+    types:
+        - completed
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: coverage-artifact
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: tests
+          name: codecov-umbrella
+          fail_ci_if_error: true

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -26,3 +26,9 @@ jobs:
     - name: Run pytest
       run: |
         pytest --cov --no-cov-on-fail --cov-report=term-missing:skip-covered --cov-report xml:coverage.xml
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage-artifact
+        path: ./coverage.xml
+        retention-days: 5


### PR DESCRIPTION
This PR adds auto CodeCov runs to the GitHub Actions workflows CI. The first commits use separate workflows with stated dependencies, but it's not clear that artifact sharing works between workflows. Will test that now, and otherwise use an external package for handling workflow-independent artifact sharing.